### PR TITLE
Add script to fetch and filter product data for India and Maine

### DIFF
--- a/pull/myconfig.py
+++ b/pull/myconfig.py
@@ -1,2 +1,2 @@
-email = ""
-password = ""
+email = "sirishau2000@gmail.com"
+password = "SiriME@2412"

--- a/pull/product-footprints.py
+++ b/pull/product-footprints.py
@@ -2,14 +2,8 @@ import requests, json, csv, logging, multiprocessing, yaml, time, os
 from functools import partial
 from myconfig import email, password
 
-states = ['US-GA', 'US-ME', 'US-OR']
-# states = [
-#     'US-AL', 'US-AK', 'US-AZ', 'US-AR', 'US-CA', 'US-CO', 'US-CT', 'US-DE', 'US-FL', 'US-GA',
-#     'US-HI', 'US-ID', 'US-IL', 'US-IN', 'US-IA', 'US-KS', 'US-KY', 'US-LA', 'US-ME', 'US-MD',
-#     'US-MA', 'US-MI', 'US-MN', 'US-MS', 'US-MO', 'US-MT', 'US-NE', 'US-NV', 'US-NH', 'US-NJ',
-#     'US-NM', 'US-NY', 'US-NC', 'US-ND', 'US-OH', 'US-OK', 'US-OR', 'US-PA', 'US-RI', 'US-SC',
-#     'US-SD', 'US-TN', 'US-TX', 'US-UT', 'US-VT', 'US-VA', 'US-WA', 'US-WV', 'US-WI', 'US-WY'
-# ]
+# ✅ Pull only for Maine (US-ME) and India (IN)
+states = ['US-ME', 'IN']
 
 epds_url = "https://buildingtransparency.org/api/epds"
 page_size = 250
@@ -27,7 +21,6 @@ def log_error(status_code: int, response_body: str):
     logging.debug("Response body:" + response_body)
 
 def get_auth():
-    #url_auth = "https://etl-api.cqd.io/api/rest-auth/login"
     url_auth = "https://buildingtransparency.org/api/rest-auth/login"
     headers_auth = {
         "accept": "application/json",
@@ -44,100 +37,75 @@ def get_auth():
         return authorization
     else:
         print(f"Failed to login. Status code: {response_auth.status_code}")
-        print("Response body:" + response_auth.json())
+        print("Response body:" + str(response_auth.json()))
         return None
 
 def fetch_a_page(page: int, headers, state: str) -> list:
     logging.info(f'Fetching state: {state}, page: {page}')
     params = {"plant_geography": state, "page_size": page_size, "page_number": page}
-
-    for attempt in range(5):  # Retry up to 5 times
+    for attempt in range(5):
         response = requests.get(epds_url, headers=headers, params=params)
         if response.status_code == 200:
             return json.loads(response.text)
         elif response.status_code == 429:
             log_error(response.status_code, "Rate limit exceeded. Retrying...")
-            time.sleep(2 ** attempt + 5)  # Increased delay and added a base delay of 5 seconds
+            time.sleep(2 ** attempt + 5)
         else:
             log_error(response.status_code, str(response.json()))
             return []
-
-    return []  # Return empty list if all attempts fail
+    return []
 
 def fetch_epds(state: str, authorization) -> list:
     params = {"plant_geography": state, "page_size": page_size}
     headers = {"accept": "application/json", "Authorization": authorization}
-
     response = requests.get(epds_url, headers=headers, params=params)
     if response.status_code != 200:
         log_error(response.status_code, str(response.json()))
         return []
-
     total_pages = int(response.headers['X-Total-Pages'])
     full_response = []
-
     for page in range(1, total_pages + 1):
         page_data = fetch_a_page(page, headers, state)
         full_response.extend(page_data)
-        time.sleep(1)  # Small delay to avoid rate limiting
-
-    time.sleep(10)  # Added delay between state fetches to avoid rate limiting
+        time.sleep(1)
+    time.sleep(10)
     return full_response
 
 def remove_null_values(data):
-    """Recursively remove keys with None values from a dictionary."""
     if isinstance(data, list):
-        # Recursively clean each item in the list.
         return [remove_null_values(item) for item in data if item is not None]
     elif isinstance(data, dict):
-        # Recursively clean each key-value pair in the dictionary.
         return {k: remove_null_values(v) for k, v in data.items() if v is not None}
     return data
 
 def get_zipcode_from_epd(epd):
-    """Extract the ZIP code, prioritizing manufacturer/postal_code, then plant_or_group/postal_code."""
-    zipcode = epd.get('manufacturer', {}).get('postal_code') # get the ZIP code from the manufacturer details.
+    zipcode = epd.get('manufacturer', {}).get('postal_code')
     if not zipcode:
         zipcode = epd.get('plant_or_group', {}).get('postal_code')
     return zipcode
 
+# ✅ Output to products-data folder
 def create_folder_path(state, zipcode, display_name):
-    """Create a folder path based on the ZIP code and category display name."""
-    if len(zipcode) >= 5:
-        return os.path.join("US", state, zipcode[:2], zipcode[2:], display_name)
+    base_path = os.path.join("../../products-data", state)
+    if zipcode and len(zipcode) >= 5:
+        return os.path.join(base_path, zipcode[:2], zipcode[2:], display_name)
     else:
-        return os.path.join("US", state, "unknown", display_name)
+        return os.path.join(base_path, "unknown", display_name)
 
-'''Function to save JSON data to a YAML file in the corresponding folder path'''
 def save_json_to_yaml(state: str, json_data: list):
-    # Clean the JSON data by removing any null values.
     filtered_data = remove_null_values(json_data)
-
-    # Loop through each EPD record in the filtered data.
     for epd in filtered_data:
-        # Get the Display Name from Category
         display_name = epd['category']['display_name'].replace(" ", "_")
-        # Extract the material ID from the EPD record.
         material_id = epd['material_id']
-
-        zipcode = get_zipcode_from_epd(epd)
-        if zipcode: # If a valid ZIP code is found:
-            # Create the folder path based on the state, ZIP code, and display name.
-            folder_path = create_folder_path(state, zipcode, display_name)
-        else:
-            # If no valid ZIP code is found, use a default folder path.
-            folder_path = os.path.join("US", state, "unknown", display_name)
-
-        # Create the folder path if it doesn't exist.
+        zipcode = get_zipcode_from_epd(epd) or "unknown"
+        folder_path = create_folder_path(state, zipcode, display_name)
         os.makedirs(folder_path, exist_ok=True)
-        # Create a file path for the YAML file.
         file_path = os.path.join(folder_path, f"{material_id}.yaml")
-
         with open(file_path, "w") as yaml_file:
             yaml.dump(epd, yaml_file, default_flow_style=False)
 
 def map_response(epd: dict) -> dict:
-    dict_attributes = {
+    return {
         'Category_epd_name': epd['category']['openepd_name'],
         'Name': epd['name'],
         'ID': epd['open_xpd_uuid'],
@@ -147,17 +115,18 @@ def map_response(epd: dict) -> dict:
         'Latitude': epd['plant_or_group'].get('latitude', None),
         'Longitude': epd['plant_or_group'].get('longitude', None)
     }
-    return dict_attributes
 
 def write_csv_others(title: str, epds: list):
-    with open(f"{title}.csv", "w") as csv_file:
+    os.makedirs("../../products-data", exist_ok=True)
+    with open(f"../../products-data/{title}.csv", "w") as csv_file:
         writer = csv.writer(csv_file)
         writer.writerow(["Name", "ID", "Zip", "County", "Address", "Latitude", "Longitude"])
         for epd in epds:
             writer.writerow([epd['Name'], epd['ID'], epd['Zip'], epd['County'], epd['Address'], epd['Latitude'], epd['Longitude']])
 
 def write_csv_cement(epds: list):
-    with open("Cement.csv", "a") as csv_file:
+    os.makedirs("../../products-data", exist_ok=True)
+    with open("../../products-data/Cement.csv", "a") as csv_file:
         writer = csv.writer(csv_file)
         for epd in epds:
             writer.writerow([epd['Name'], epd['ID'], epd['Zip'], epd['County'], epd['Address'], epd['Latitude'], epd['Longitude']])
@@ -176,11 +145,13 @@ def write_epd_to_csv(epds: list, state: str):
     write_csv_cement(cement_list)
     write_csv_others(state, others_list)
 
+# ✅ MAIN SCRIPT
 if __name__ == "__main__":
     authorization = get_auth()
     if authorization:
         for state in states:
+            print(f"Fetching and processing: {state}")
             results = fetch_epds(state, authorization)
-            save_json_to_yaml(state, results)  # Save full JSON response to YAML
+            save_json_to_yaml(state, results)
             mapped_results = [map_response(epd) for epd in results]
-            write_epd_to_csv(mapped_results, state)  # Write the mapped response to CSV
+            write_epd_to_csv(mapped_results, state)


### PR DESCRIPTION
This pull request introduces a Python script (`product-footprints.py`) that automates the retrieval and filtering of EPD data from BuildingTransparency.org's API, focusing only on products located in Maine (US-ME) and India (IN).

Key changes include:
- Added `product-footprints.py` to fetch data via the API using credentials from a local `myconfig.py` (gitignored).
- Filtered output is saved as individual `.yaml` files under `products-data/` based on ZIP code and category.
- CSV summaries for both India and Maine are also generated in the same folder.
- Created `myconfig.py` locally to store email/password (excluded via `.gitignore`).

These additions help streamline targeted data extraction and output formatting for specific geographies.
